### PR TITLE
#39 enable bundling assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ existing build command to use `liferay-npm-bundler-improved` instead of `liferay
 > See `examples/plain` for an example
 #### Old
 ```
-"build": "pnpm run copy-sources && liferay-npm-bundler"
+"build": "lnbs-copy-sources && liferay-npm-bundler"
 ```
 #### New
 ```
-"build": "liferay-npm-bundler-improved"
+"build": "liferay-npm-bundler-improved --copy-sources"
 ```
 
 ### With bundle process
@@ -36,6 +36,19 @@ existing build command to use `liferay-npm-bundler-improved` instead of `liferay
 ```
 "build": "rollup -c && liferay-npm-bundler-improved"
 ```
+
+### Assets
+If you'd like to have the content of the `assets` folder available through the web-context url, you can add the
+`--copy-assets` param to your `liferay-npm-bundler-improved` call
+> See `examples/plain` for an example
+#### Old
+```
+"build": "lnbs-copy-assets && liferay-npm-bundler"
+```
+#### New
+```
+"build": "liferay-npm-bundler-improved --copy-assets"
+``` 
 
 ## Additional Information
 > Where is the official bundler?

--- a/bundler/package.json
+++ b/bundler/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@types/archiver": "^5.1.1",
-    "archiver": "^5.3.0"
+    "archiver": "^5.3.0",
+    "arg": "^5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/bundler/package.json
+++ b/bundler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liferay-npm-bundler-improved",
   "description": "A highly experimental and non-official module which bundles the javascript into the liferay loader and creates a jar file.",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": "Jonas Wanner",
   "license": "ISC",
   "repository": {
@@ -27,7 +27,9 @@
   "dependencies": {
     "@types/archiver": "^5.1.1",
     "archiver": "^5.3.0",
-    "arg": "^5.0.1"
+    "arg": "^5.0.1",
+    "chalk": "^4.1.2",
+    "regenerator-runtime": "^0.13.9"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",
@@ -38,7 +40,6 @@
     "@rollup/plugin-json": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "4.0.0",
-    "chalk": "^4.1.2",
     "esbuild": "^0.12.28",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/bundler/rollup.config.ts
+++ b/bundler/rollup.config.ts
@@ -37,7 +37,16 @@ const config: RollupOptions = {
       banner: '#!/usr/bin/env node'
     }
   ],
-  external: ['fs', 'util', 'regenerator-runtime/runtime', 'path', 'archiver', 'chalk', 'readline', 'arg']
+  external: [
+    'fs',
+    'util',
+    'regenerator-runtime/runtime',
+    'path',
+    'archiver',
+    'chalk',
+    'readline',
+    'arg'
+  ]
 }
 
 export default config

--- a/bundler/rollup.config.ts
+++ b/bundler/rollup.config.ts
@@ -37,7 +37,7 @@ const config: RollupOptions = {
       banner: '#!/usr/bin/env node'
     }
   ],
-  external: ['fs', 'util', 'regenerator-runtime/runtime', 'path', 'archiver', 'chalk', 'readline']
+  external: ['fs', 'util', 'regenerator-runtime/runtime', 'path', 'archiver', 'chalk', 'readline', 'arg']
 }
 
 export default config

--- a/bundler/src/exceptions/CopyAssetsException.ts
+++ b/bundler/src/exceptions/CopyAssetsException.ts
@@ -1,0 +1,6 @@
+export default class CopyAssetsException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CopyAssetsException'
+  }
+}

--- a/bundler/src/exceptions/CopySourcesException.ts
+++ b/bundler/src/exceptions/CopySourcesException.ts
@@ -1,0 +1,6 @@
+export default class CopySourcesException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CopySourcesException'
+  }
+}

--- a/bundler/src/exceptions/MissingEntryFileException.ts
+++ b/bundler/src/exceptions/MissingEntryFileException.ts
@@ -1,0 +1,6 @@
+export default class MissingEntryFileException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MissingEntryFileException'
+  }
+}

--- a/bundler/src/exceptions/TemplateSealException.ts
+++ b/bundler/src/exceptions/TemplateSealException.ts
@@ -1,0 +1,6 @@
+export default class TemplateSealException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TemplateSealException'
+  }
+}

--- a/bundler/src/handler/FeaturesHandler.ts
+++ b/bundler/src/handler/FeaturesHandler.ts
@@ -11,7 +11,7 @@ export default class FeaturesHandler {
 
   async resolve(): Promise<void> {
     try {
-      const file = await promisify(readFile)('./.npmbundlerrc')
+      const file = await promisify(readFile)(`.${sep}.npmbundlerrc`)
       this.npmbundlerrc = await JSON.parse(file.toString())
     } catch {
       // npmbundlerrc could not be found. is not required
@@ -26,9 +26,9 @@ export default class FeaturesHandler {
         const path = this.npmbundlerrc?.['create-jar']?.features?.localization
 
         if (path) {
-          const split = path.split('/')
+          const split = path.split(sep)
           split.pop()
-          this.localizationPath = split.join('/')
+          this.localizationPath = split.join(sep)
         }
       }
     }

--- a/bundler/src/handler/FileHandler.ts
+++ b/bundler/src/handler/FileHandler.ts
@@ -1,0 +1,25 @@
+import { readdir, stat, mkdir } from 'fs'
+import { resolve } from 'path'
+import { promisify } from 'util'
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class FileHandler {
+  static async createFolderStructure (path: string): Promise<void> {
+    try {
+      await promisify(mkdir)(path, { recursive: true })
+    } catch {
+      // silent
+    }
+  }
+
+  static async getFiles(directory): Promise<string[]> {
+    const subs = await promisify(readdir)(directory)
+    const files = await Promise.all(
+      subs.map(async (sub) => {
+        const res = resolve(directory, sub)
+        return (await promisify(stat)(res)).isDirectory() ? await this.getFiles(res) : res
+      })
+    )
+    return Array.from(files.reduce((a, f) => a.concat(f as string), []))
+  }
+}

--- a/bundler/src/handler/JarHandler.ts
+++ b/bundler/src/handler/JarHandler.ts
@@ -4,6 +4,7 @@ import { sep } from 'path'
 import { promisify } from 'util'
 import Pack from '../types/Pack.types'
 import npmbundlerrc from '../types/npmbundlerrc.types'
+import { FileHandler } from './FileHandler'
 
 export default class JarHandler {
   public name: string
@@ -21,11 +22,7 @@ export default class JarHandler {
       outputDir = dir
     }
 
-    try {
-      await promisify(mkdir)(`.${sep}${outputDir}`, { recursive: true })
-    } catch {
-      // silent
-    }
+    await FileHandler.createFolderStructure(`.${sep}${outputDir}`)
 
     this.output = createWriteStream(`${outputDir}${sep}${this.name}.jar`)
 

--- a/bundler/src/handler/ProcessHandler.ts
+++ b/bundler/src/handler/ProcessHandler.ts
@@ -1,16 +1,16 @@
 import { access, copyFile, mkdir, readdir, readFile, rm, stat } from 'fs'
-import { sep, resolve } from 'path'
+import { resolve, sep } from 'path'
 import { promisify } from 'util'
 import { version } from '../../package.json'
+import CopyAssetsException from '../exceptions/CopyAssetsException'
+import CopySourcesException from '../exceptions/CopySourcesException'
+import MissingEntryFileException from '../exceptions/MissingEntryFileException'
 import { log } from '../log'
 import FeaturesHandler from './FeaturesHandler'
 import JarHandler from './JarHandler'
 import PackageHandler from './PackageHandler'
-import TemplateHandler from './TemplateHandler'
 import SettingsHandler from './SettingsHandler'
-import MissingEntryFileException from '../exceptions/MissingEntryFileException'
-import CopySourcesException from '../exceptions/CopySourcesException'
-import CopyAssetsException from '../exceptions/CopyAssetsException'
+import TemplateHandler from './TemplateHandler'
 
 export default class ProcessHandler {
   private entryPoint: string
@@ -117,10 +117,7 @@ export default class ProcessHandler {
         ',liferay.resource.bundle;resource.bundle.base.name="content.Language"'
       )
     } else {
-      manifestMFTemplate.replace(
-        'language-resource',
-        ''
-      )
+      manifestMFTemplate.replace('language-resource', '')
     }
 
     // process manifest.json
@@ -171,7 +168,7 @@ export default class ProcessHandler {
       const files = await this.getFiles(`.${sep}assets`)
 
       for (const file of files) {
-        const relative = file.split("assets").pop()
+        const relative = file.split('assets').pop()
 
         this.jarHandler.archive.append(await promisify(readFile)(file), {
           name: `/META-INF/resources/${relative}`
@@ -182,10 +179,12 @@ export default class ProcessHandler {
 
   async getFiles(directory): Promise<string[]> {
     const subs = await promisify(readdir)(directory)
-    const files = await Promise.all(subs.map(async (sub) => {
-      const res = resolve(directory, sub)
-      return (await promisify(stat)(res)).isDirectory() ? await this.getFiles(res) : res
-    }))
+    const files = await Promise.all(
+      subs.map(async (sub) => {
+        const res = resolve(directory, sub)
+        return (await promisify(stat)(res)).isDirectory() ? await this.getFiles(res) : res
+      })
+    )
     return Array.from(files.reduce((a, f) => a.concat(f as string), []))
   }
 

--- a/bundler/src/handler/ProcessHandler.ts
+++ b/bundler/src/handler/ProcessHandler.ts
@@ -104,6 +104,10 @@ export default class ProcessHandler {
     wrapperJsTemplate.replace('bundle', (await promisify(readFile)(this.entryPath)).toString())
     await wrapperJsTemplate.seal(this.settingsHandler, this.entryPath)
 
+    if (!this.settingsHandler.createJar) {
+      return
+    }
+
     // process MANIFEST.MF
     const manifestMFTemplate = new TemplateHandler('MANIFEST.MF')
     await manifestMFTemplate.resolve()

--- a/bundler/src/handler/SettingsHandler.ts
+++ b/bundler/src/handler/SettingsHandler.ts
@@ -6,13 +6,13 @@ export default class SettingsHandler {
   public copyAssets = false
   public copySources = false
 
-  constructor () {
+  constructor() {
     const args = arg({
       '--copy-sources': Boolean,
       '-cs': '--copy-sources',
       '--copy-assets': Boolean,
       '-ca': '--copy-assets'
-    });
+    })
 
     if (args['--copy-sources']) {
       this.copySources = true
@@ -22,7 +22,7 @@ export default class SettingsHandler {
     }
   }
 
-  public resolve (npmbundlerrc: npmbundlerrc): void {
+  public resolve(npmbundlerrc: npmbundlerrc): void {
     if (npmbundlerrc['create-jar']) {
       this.createJar = true
     }

--- a/bundler/src/handler/SettingsHandler.ts
+++ b/bundler/src/handler/SettingsHandler.ts
@@ -1,0 +1,30 @@
+import arg from 'arg'
+import npmbundlerrc from '../types/npmbundlerrc.types'
+
+export default class SettingsHandler {
+  public createJar = false
+  public copyAssets = false
+  public copySources = false
+
+  constructor () {
+    const args = arg({
+      '--copy-sources': Boolean,
+      '-cs': '--copy-sources',
+      '--copy-assets': Boolean,
+      '-ca': '--copy-assets'
+    });
+
+    if (args['--copy-sources']) {
+      this.copySources = true
+    }
+    if (args['--copy-assets']) {
+      this.copyAssets = true
+    }
+  }
+
+  public resolve (npmbundlerrc: npmbundlerrc): void {
+    if (npmbundlerrc['create-jar']) {
+      this.createJar = true
+    }
+  }
+}

--- a/bundler/src/handler/TemplateHandler.ts
+++ b/bundler/src/handler/TemplateHandler.ts
@@ -1,4 +1,4 @@
-import { access, readFile, writeFile, mkdir } from 'fs'
+import { access, mkdir, readFile, writeFile } from 'fs'
 import { sep } from 'path'
 import { promisify } from 'util'
 import TemplatesNotFoundException from '../exceptions/TemplatesNotFoundException'
@@ -35,7 +35,7 @@ export default class TemplateHandler {
     this.processed = this.raw.toString()
   }
 
-  async seal (settingsHandler: SettingsHandler, name?: string): Promise<void> {
+  async seal(settingsHandler: SettingsHandler, name?: string): Promise<void> {
     if (!settingsHandler.createJar) {
       try {
         await promisify(mkdir)(`.${sep}build`)
@@ -46,7 +46,7 @@ export default class TemplateHandler {
       try {
         await promisify(writeFile)(name ?? this.name, this.processed)
       } catch (e) {
-        throw new TemplatesNotFoundException(`failed to save '${name ?? this.name}' in 'build'`);
+        throw new TemplatesNotFoundException(`failed to save '${name ?? this.name}' in 'build'`)
       }
     }
   }

--- a/bundler/src/mod.ts
+++ b/bundler/src/mod.ts
@@ -2,9 +2,11 @@ import 'regenerator-runtime/runtime'
 import { name, version } from '../package.json'
 import ProcessHandler from './handler/ProcessHandler'
 import { log } from './log'
+import SettingsHandler from './handler/SettingsHandler'
 
 void (async () => {
-  const process = new ProcessHandler()
+  const settingsHandler = new SettingsHandler()
+  const process = new ProcessHandler(settingsHandler)
 
   console.log(`${name} - ${version}`)
 

--- a/bundler/src/mod.ts
+++ b/bundler/src/mod.ts
@@ -25,6 +25,7 @@ void (async () => {
       .replace(/((?<=[a-z\d])[A-Z]|(?<=[A-Z\d])[A-Z](?=[a-z]))/g, '-$1')
       .toLowerCase()
     log.error(`bundler failed. ${kebab}`)
+    process.exitCode = 1;
   }
 
   log.close()

--- a/bundler/src/mod.ts
+++ b/bundler/src/mod.ts
@@ -13,7 +13,10 @@ void (async () => {
   try {
     await process.prepare()
     await process.process()
-    await process.create()
+
+    if (settingsHandler.createJar) {
+      await process.create()
+    }
 
     log.success('bundler done')
   } catch (exception) {

--- a/bundler/src/mod.ts
+++ b/bundler/src/mod.ts
@@ -17,7 +17,8 @@ void (async () => {
 
     log.success('bundler done')
   } catch (exception) {
-    log.error(`bundler failed: ${exception as string}`)
+    const kebab: string = exception.toString().replace(/((?<=[a-z\d])[A-Z]|(?<=[A-Z\d])[A-Z](?=[a-z]))/g, '-$1').toLowerCase()
+    log.error(`bundler failed. ${kebab}`)
   }
 
   log.close()

--- a/bundler/src/mod.ts
+++ b/bundler/src/mod.ts
@@ -5,12 +5,12 @@ import SettingsHandler from './handler/SettingsHandler'
 import { log } from './log'
 
 void (async () => {
-  const settingsHandler = new SettingsHandler()
-  const process = new ProcessHandler(settingsHandler)
-
   console.log(`${name} - ${version}`)
 
   try {
+    const settingsHandler = new SettingsHandler()
+    const process = new ProcessHandler(settingsHandler)
+
     await process.prepare()
     await process.process()
 

--- a/bundler/src/mod.ts
+++ b/bundler/src/mod.ts
@@ -1,8 +1,8 @@
 import 'regenerator-runtime/runtime'
 import { name, version } from '../package.json'
 import ProcessHandler from './handler/ProcessHandler'
-import { log } from './log'
 import SettingsHandler from './handler/SettingsHandler'
+import { log } from './log'
 
 void (async () => {
   const settingsHandler = new SettingsHandler()
@@ -17,7 +17,10 @@ void (async () => {
 
     log.success('bundler done')
   } catch (exception) {
-    const kebab: string = exception.toString().replace(/((?<=[a-z\d])[A-Z]|(?<=[A-Z\d])[A-Z](?=[a-z]))/g, '-$1').toLowerCase()
+    const kebab: string = exception
+      .toString()
+      .replace(/((?<=[a-z\d])[A-Z]|(?<=[A-Z\d])[A-Z](?=[a-z]))/g, '-$1')
+      .toLowerCase()
     log.error(`bundler failed. ${kebab}`)
   }
 

--- a/bundler/src/types/npmbundlerrc.types.ts
+++ b/bundler/src/types/npmbundlerrc.types.ts
@@ -4,6 +4,7 @@ interface npmbundlerrc {
 
 interface createJar {
   features?: features
+  'output-dir'?: string
 }
 
 interface features {

--- a/examples/plain/assets/asset.txt
+++ b/examples/plain/assets/asset.txt
@@ -1,0 +1,1 @@
+Sample file which showcases the possibility of assets.

--- a/examples/plain/assets/sub/sub-asset.txt
+++ b/examples/plain/assets/sub/sub-asset.txt
@@ -1,0 +1,1 @@
+Sample file which showcases the possibility of assets.

--- a/examples/plain/package.json
+++ b/examples/plain/package.json
@@ -3,7 +3,7 @@
   "description": "plain",
   "version": "1.0.0",
   "scripts": {
-    "build": "liferay-npm-bundler-improved",
+    "build": "liferay-npm-bundler-improved --copy-sources --copy-assets",
     "old:build": "pnpm run copy-sources && pnpm run copy-assets && liferay-npm-bundler",
     "copy-assets": "lnbs-copy-assets",
     "copy-sources": "lnbs-copy-sources"
@@ -17,8 +17,8 @@
   },
   "main": "index",
   "devDependencies": {
-    "liferay-npm-bundler-improved": "workspace:^",
     "liferay-npm-build-support": "^2.25.0",
-    "liferay-npm-bundler": "^2.25.0"
+    "liferay-npm-bundler": "^2.25.0",
+    "liferay-npm-bundler-improved": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,8 @@ importers:
       '@types/archiver': 5.1.1
       archiver: 5.3.0
       arg: 5.0.1
+      chalk: 4.1.2
+      regenerator-runtime: 0.13.9
     devDependencies:
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11_@babel+core@7.17.9
@@ -48,7 +50,6 @@ importers:
       '@rollup/plugin-json': 4.1.0_rollup@2.60.2
       '@typescript-eslint/eslint-plugin': 4.33.0_jsmtk5xgxernuvx5nhrjfm3jh4
       '@typescript-eslint/parser': 4.0.0_wnilx7boviscikmvsfkd6ljepe
-      chalk: 4.1.2
       esbuild: 0.12.29
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
@@ -59,7 +60,6 @@ importers:
       prettier: 2.5.0
       prettier-plugin-organize-imports: 2.3.4_5j2uxzfklibigmd5tyodhypk6e
       readline: 1.3.0
-      regenerator-runtime: 0.13.9
       rollup: 2.60.2
       rollup-plugin-copy: 3.4.0
       rollup-plugin-esbuild: 4.7.2_6o6s27zuiu65oylrocermxngny
@@ -1961,7 +1961,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /archiver-utils/2.1.0:
     resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
@@ -2447,7 +2446,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /clean-css/4.2.4:
     resolution: {integrity: sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==}
@@ -2480,7 +2478,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
@@ -2488,7 +2485,6 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /colorette/1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
@@ -3547,7 +3543,6 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-symbols/1.0.2:
     resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==}
@@ -4612,7 +4607,6 @@ packages:
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
-    dev: true
 
   /regenerator-transform/0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
@@ -5084,7 +5078,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /table/6.7.3:
     resolution: {integrity: sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -17,6 +17,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^4.31.2
       '@typescript-eslint/parser': 4.0.0
       archiver: ^5.3.0
+      arg: ^5.0.1
       chalk: ^4.1.2
       esbuild: ^0.12.28
       eslint: ^7.32.0
@@ -37,30 +38,31 @@ importers:
     dependencies:
       '@types/archiver': 5.1.1
       archiver: 5.3.0
+      arg: 5.0.1
     devDependencies:
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11_@babel+core@7.17.9
-      '@rollup/plugin-babel': 5.3.1_@babel+core@7.17.9+rollup@2.60.2
+      '@rollup/plugin-babel': 5.3.1_5a5p3qindzp4eh2o4wokhftjeq
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.60.2
       '@rollup/plugin-eslint': 8.0.1_rollup@2.60.2
       '@rollup/plugin-json': 4.1.0_rollup@2.60.2
-      '@typescript-eslint/eslint-plugin': 4.33.0_4c993576e6b922da56fd69e292b3693f
-      '@typescript-eslint/parser': 4.0.0_eslint@7.32.0+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 4.33.0_jsmtk5xgxernuvx5nhrjfm3jh4
+      '@typescript-eslint/parser': 4.0.0_wnilx7boviscikmvsfkd6ljepe
       chalk: 4.1.2
       esbuild: 0.12.29
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
-      eslint-config-standard-with-typescript: 21.0.1_7011e4c6b6506c7ee39552f76c4c1b28
-      eslint-plugin-import: 2.25.3_eslint@7.32.0
+      eslint-config-standard-with-typescript: 21.0.1_oai6jrvwkbwh5y4vkl3wyta3fa
+      eslint-plugin-import: 2.25.3_cxmo2kyoere6f7tblsdv7itcme
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-promise: 5.1.1_eslint@7.32.0
       prettier: 2.5.0
-      prettier-plugin-organize-imports: 2.3.4_prettier@2.5.0+typescript@4.4.4
+      prettier-plugin-organize-imports: 2.3.4_5j2uxzfklibigmd5tyodhypk6e
       readline: 1.3.0
       regenerator-runtime: 0.13.9
       rollup: 2.60.2
       rollup-plugin-copy: 3.4.0
-      rollup-plugin-esbuild: 4.7.2_esbuild@0.12.29+rollup@2.60.2
+      rollup-plugin-esbuild: 4.7.2_6o6s27zuiu65oylrocermxngny
       rollup-plugin-preserve-shebangs: 0.2.0_rollup@2.60.2
       typescript: 4.4.4
 
@@ -98,13 +100,13 @@ importers:
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.60.2
       '@rollup/plugin-node-resolve': 13.1.3_rollup@2.60.2
       '@rollup/plugin-replace': 3.1.0_rollup@2.60.2
-      '@rollup/plugin-typescript': 8.3.1_ba9b3ddd21177de03366a2e63c907dd9
+      '@rollup/plugin-typescript': 8.3.1_xknt3xjbc566am3gultdzed53e
       '@types/react': 17.0.43
       '@types/react-dom': 17.0.14
       esbuild: 0.12.29
       liferay-npm-bundler-improved: link:../../bundler
       rollup: 2.60.2
-      rollup-plugin-esbuild: 4.7.2_esbuild@0.12.29+rollup@2.60.2
+      rollup-plugin-esbuild: 4.7.2_6o6s27zuiu65oylrocermxngny
       typescript: 4.4.3
 
   examples/vue:
@@ -130,8 +132,8 @@ importers:
       liferay-npm-bundler-improved: link:../../bundler
       postcss: 8.4.12
       rollup: 2.60.2
-      rollup-plugin-esbuild: 4.7.2_esbuild@0.12.29+rollup@2.60.2
-      rollup-plugin-vue: 4.7.2_84f1ab3facf9297d480226d5fd2946c7
+      rollup-plugin-esbuild: 4.7.2_6o6s27zuiu65oylrocermxngny
+      rollup-plugin-vue: 4.7.2_qty2wp5m7eux2sace3k72kkgy4
       vue-template-compiler: 2.6.14
 
 packages:
@@ -159,29 +161,6 @@ packages:
   /@babel/compat-data/7.17.7:
     resolution: {integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/core/7.17.8:
-    resolution: {integrity: sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.1.2
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.17.7
-      '@babel/helper-compilation-targets': 7.17.7_@babel+core@7.17.8
-      '@babel/helper-module-transforms': 7.17.7
-      '@babel/helpers': 7.17.8
-      '@babel/parser': 7.17.8
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      convert-source-map: 1.8.0
-      debug: 4.3.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/core/7.17.9:
@@ -238,19 +217,6 @@ packages:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
       '@babel/types': 7.17.0
-    dev: true
-
-  /@babel/helper-compilation-targets/7.17.7_@babel+core@7.17.8:
-    resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.17.7
-      '@babel/core': 7.17.8
-      '@babel/helper-validator-option': 7.16.7
-      browserslist: 4.20.2
-      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets/7.17.7_@babel+core@7.17.9:
@@ -467,17 +433,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helpers/7.17.8:
-    resolution: {integrity: sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helpers/7.17.9:
     resolution: {integrity: sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==}
     engines: {node: '>=6.9.0'}
@@ -511,12 +466,16 @@ packages:
     resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/parser/7.17.9:
     resolution: {integrity: sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.9:
@@ -1440,7 +1399,7 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_@babel+core@7.17.9+rollup@2.60.2:
+  /@rollup/plugin-babel/5.3.1_5a5p3qindzp4eh2o4wokhftjeq:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1520,7 +1479,7 @@ packages:
       rollup: 2.60.2
     dev: true
 
-  /@rollup/plugin-typescript/8.3.1_ba9b3ddd21177de03366a2e63c907dd9:
+  /@rollup/plugin-typescript/8.3.1_xknt3xjbc566am3gultdzed53e:
     resolution: {integrity: sha512-84rExe3ICUBXzqNX48WZV2Jp3OddjTMX97O2Py6D1KJaGSwWp0mDHXj+bCGNJqWHIEKDIT2U0sDjhP4czKi6cA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1623,7 +1582,7 @@ packages:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.33.0_4c993576e6b922da56fd69e292b3693f:
+  /@typescript-eslint/eslint-plugin/4.33.0_jsmtk5xgxernuvx5nhrjfm3jh4:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1634,8 +1593,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.4.4
-      '@typescript-eslint/parser': 4.0.0_eslint@7.32.0+typescript@4.4.4
+      '@typescript-eslint/experimental-utils': 4.33.0_wnilx7boviscikmvsfkd6ljepe
+      '@typescript-eslint/parser': 4.0.0_wnilx7boviscikmvsfkd6ljepe
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.3
       eslint: 7.32.0
@@ -1649,7 +1608,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.33.0_eslint@7.32.0+typescript@4.4.4:
+  /@typescript-eslint/experimental-utils/4.33.0_wnilx7boviscikmvsfkd6ljepe:
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1667,7 +1626,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.0.0_eslint@7.32.0+typescript@4.4.4:
+  /@typescript-eslint/parser/4.0.0_wnilx7boviscikmvsfkd6ljepe:
     resolution: {integrity: sha512-KuBwTUzc3G3dD5k9ybTjgqIQjjJPY6WPaEoxdNS5vN5XV/Tixp0itA14+NQlbeswTHvsELaKXZhynxD/O2wHFA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1687,7 +1646,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_eslint@7.32.0+typescript@4.4.4:
+  /@typescript-eslint/parser/4.33.0_wnilx7boviscikmvsfkd6ljepe:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1804,9 +1763,63 @@ packages:
       prettier: 1.16.3
       source-map: 0.6.1
       vue-template-es2015-compiler: 1.9.1
+    transitivePeerDependencies:
+      - arc-templates
+      - atpl
+      - babel-core
+      - bracket-template
+      - coffee-script
+      - dot
+      - dust
+      - dustjs-helpers
+      - dustjs-linkedin
+      - eco
+      - ect
+      - ejs
+      - haml-coffee
+      - hamlet
+      - hamljs
+      - handlebars
+      - hogan.js
+      - htmling
+      - jade
+      - jazz
+      - jqtpl
+      - just
+      - liquid-node
+      - liquor
+      - lodash
+      - marko
+      - mote
+      - mustache
+      - nunjucks
+      - plates
+      - pug
+      - qejs
+      - ractive
+      - razor-tmpl
+      - react
+      - react-dom
+      - slm
+      - squirrelly
+      - swig
+      - swig-templates
+      - teacup
+      - templayed
+      - then-jade
+      - then-pug
+      - tinyliquid
+      - toffee
+      - twig
+      - twing
+      - underscore
+      - vash
+      - velocityjs
+      - walrus
+      - whiskers
     dev: true
 
-  /@vue/component-compiler/3.6.0_84f1ab3facf9297d480226d5fd2946c7:
+  /@vue/component-compiler/3.6.0_qty2wp5m7eux2sace3k72kkgy4:
     resolution: {integrity: sha512-NIA0vmOI4zbtJAn69iZls8IJ8VxmguswAuiUdu8TcR+YYTYzntfw290HUCSFjzAdRg+FUWZv8r+wc3TzJ/IjwA==}
     peerDependencies:
       postcss: '>=6.0'
@@ -1819,6 +1832,60 @@ packages:
       postcss-modules-sync: 1.0.0
       source-map: 0.6.1
       vue-template-compiler: 2.6.14
+    transitivePeerDependencies:
+      - arc-templates
+      - atpl
+      - babel-core
+      - bracket-template
+      - coffee-script
+      - dot
+      - dust
+      - dustjs-helpers
+      - dustjs-linkedin
+      - eco
+      - ect
+      - ejs
+      - haml-coffee
+      - hamlet
+      - hamljs
+      - handlebars
+      - hogan.js
+      - htmling
+      - jade
+      - jazz
+      - jqtpl
+      - just
+      - liquid-node
+      - liquor
+      - lodash
+      - marko
+      - mote
+      - mustache
+      - nunjucks
+      - plates
+      - pug
+      - qejs
+      - ractive
+      - razor-tmpl
+      - react
+      - react-dom
+      - slm
+      - squirrelly
+      - swig
+      - swig-templates
+      - teacup
+      - templayed
+      - then-jade
+      - then-pug
+      - tinyliquid
+      - toffee
+      - twig
+      - twing
+      - underscore
+      - vash
+      - velocityjs
+      - walrus
+      - whiskers
     dev: true
 
   /abab/2.0.5:
@@ -1863,7 +1930,7 @@ packages:
     dev: true
 
   /ansi-regex/2.1.1:
-    resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=}
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -1878,7 +1945,7 @@ packages:
     dev: true
 
   /ansi-styles/2.2.1:
-    resolution: {integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=}
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -1925,6 +1992,10 @@ packages:
       zip-stream: 4.1.0
     dev: false
 
+  /arg/5.0.1:
+    resolution: {integrity: sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==}
+    dev: false
+
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
@@ -1963,7 +2034,7 @@ packages:
     dev: true
 
   /assert-plus/1.0.0:
-    resolution: {integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=}
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
     dev: true
 
@@ -1977,11 +2048,11 @@ packages:
     dev: false
 
   /asynckit/0.4.0:
-    resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: true
 
   /aws-sign2/0.7.0:
-    resolution: {integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=}
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
     dev: true
 
   /aws4/1.11.0:
@@ -1989,7 +2060,7 @@ packages:
     dev: true
 
   /babel-code-frame/6.26.0:
-    resolution: {integrity: sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=}
+    resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==}
     dependencies:
       chalk: 1.1.3
       esutils: 2.0.3
@@ -2018,6 +2089,8 @@ packages:
       private: 0.1.8
       slash: 1.0.0
       source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-generator/6.26.1:
@@ -2038,22 +2111,24 @@ packages:
     dev: true
 
   /babel-helper-mark-eval-scopes/0.4.3:
-    resolution: {integrity: sha1-0kSjvvmESHJgP/tG4izorN9VFWI=}
+    resolution: {integrity: sha512-+d/mXPP33bhgHkdVOiPkmYoeXJ+rXRWi7OdhwpyseIqOS8CmzHQXHUp/+/Qr8baXsT0kjGpMHHofHs6C3cskdA==}
     dev: true
 
   /babel-helper-remove-or-void/0.4.3:
-    resolution: {integrity: sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=}
+    resolution: {integrity: sha512-eYNceYtcGKpifHDir62gHJadVXdg9fAhuZEXiRQnJJ4Yi4oUTpqpNY//1pM4nVyjjDMPYaC2xSf0I+9IqVzwdA==}
     dev: true
 
   /babel-helpers/6.24.1:
-    resolution: {integrity: sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=}
+    resolution: {integrity: sha512-n7pFrqQm44TCYvrCDb0MqabAF+JUBq+ijBvNMUxpkLjJaAu32faIexewMumrH5KLLJ1HDyT0PTEqRyAe/GwwuQ==}
     dependencies:
       babel-runtime: 6.26.0
       babel-template: 6.26.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-messages/6.23.0:
-    resolution: {integrity: sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=}
+    resolution: {integrity: sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==}
     dependencies:
       babel-runtime: 6.26.0
     dev: true
@@ -2147,7 +2222,7 @@ packages:
     dev: true
 
   /babel-plugin-syntax-object-rest-spread/6.13.0:
-    resolution: {integrity: sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=}
+    resolution: {integrity: sha512-C4Aq+GaAj83pRQ0EFgTvw5YO6T3Qz2KGrNRwIj9mSoNHVvdZY4KO2uA6HNtNXCw993iSZnckY1aLW8nOi8i4+w==}
     dev: true
 
   /babel-plugin-transform-node-env-inline/0.4.3:
@@ -2167,6 +2242,8 @@ packages:
       babel-template: 6.26.0
       liferay-npm-build-tools-common: 2.28.3
       read-json-sync: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-preset-liferay-standard/2.28.3:
@@ -2182,10 +2259,12 @@ packages:
       babel-plugin-transform-node-env-inline: 0.4.3
       babel-plugin-transform-object-rest-spread: 6.26.0
       babel-plugin-wrap-modules-amd: 2.28.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-register/6.26.0:
-    resolution: {integrity: sha1-btAhFz4vy0htestFxgCahW9kcHE=}
+    resolution: {integrity: sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==}
     dependencies:
       babel-core: 6.26.3
       babel-runtime: 6.26.0
@@ -2194,27 +2273,31 @@ packages:
       lodash: 4.17.21
       mkdirp: 0.5.6
       source-map-support: 0.4.18
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-runtime/6.26.0:
-    resolution: {integrity: sha1-llxwWGaOgrVde/4E/yM3vItWR/4=}
+    resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==}
     dependencies:
       core-js: 2.6.12
       regenerator-runtime: 0.11.1
     dev: true
 
   /babel-template/6.26.0:
-    resolution: {integrity: sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=}
+    resolution: {integrity: sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==}
     dependencies:
       babel-runtime: 6.26.0
       babel-traverse: 6.26.0
       babel-types: 6.26.0
       babylon: 6.18.0
       lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-traverse/6.26.0:
-    resolution: {integrity: sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=}
+    resolution: {integrity: sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==}
     dependencies:
       babel-code-frame: 6.26.0
       babel-messages: 6.23.0
@@ -2225,10 +2308,12 @@ packages:
       globals: 9.18.0
       invariant: 2.2.4
       lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-types/6.26.0:
-    resolution: {integrity: sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=}
+    resolution: {integrity: sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==}
     dependencies:
       babel-runtime: 6.26.0
       esutils: 2.0.3
@@ -2249,7 +2334,7 @@ packages:
     dev: false
 
   /bcrypt-pbkdf/1.0.2:
-    resolution: {integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=}
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
     dependencies:
       tweetnacl: 0.14.5
     dev: true
@@ -2333,11 +2418,11 @@ packages:
     dev: true
 
   /caseless/0.12.0:
-    resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
     dev: true
 
   /chalk/1.1.3:
-    resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-styles: 2.2.1
@@ -2380,7 +2465,7 @@ packages:
     dev: true
 
   /clone/2.1.2:
-    resolution: {integrity: sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=}
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
     dev: true
 
@@ -2436,6 +2521,167 @@ packages:
   /consolidate/0.15.1:
     resolution: {integrity: sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==}
     engines: {node: '>= 0.10.0'}
+    peerDependencies:
+      arc-templates: ^0.5.3
+      atpl: '>=0.7.6'
+      babel-core: ^6.26.3
+      bracket-template: ^1.1.5
+      coffee-script: ^1.12.7
+      dot: ^1.1.3
+      dust: ^0.3.0
+      dustjs-helpers: ^1.7.4
+      dustjs-linkedin: ^2.7.5
+      eco: ^1.1.0-rc-3
+      ect: ^0.5.9
+      ejs: ^3.1.5
+      haml-coffee: ^1.14.1
+      hamlet: ^0.3.3
+      hamljs: ^0.6.2
+      handlebars: ^4.7.6
+      hogan.js: ^3.0.2
+      htmling: ^0.0.8
+      jade: ^1.11.0
+      jazz: ^0.0.18
+      jqtpl: ~1.1.0
+      just: ^0.1.8
+      liquid-node: ^3.0.1
+      liquor: ^0.0.5
+      lodash: ^4.17.20
+      marko: ^3.14.4
+      mote: ^0.2.0
+      mustache: ^4.0.1
+      nunjucks: ^3.2.2
+      plates: ~0.4.11
+      pug: ^3.0.0
+      qejs: ^3.0.5
+      ractive: ^1.3.12
+      razor-tmpl: ^1.3.1
+      react: ^16.13.1
+      react-dom: ^16.13.1
+      slm: ^2.0.0
+      squirrelly: ^5.1.0
+      swig: ^1.4.2
+      swig-templates: ^2.0.3
+      teacup: ^2.0.0
+      templayed: '>=0.2.3'
+      then-jade: '*'
+      then-pug: '*'
+      tinyliquid: ^0.2.34
+      toffee: ^0.3.6
+      twig: ^1.15.2
+      twing: ^5.0.2
+      underscore: ^1.11.0
+      vash: ^0.13.0
+      velocityjs: ^2.0.1
+      walrus: ^0.10.1
+      whiskers: ^0.4.0
+    peerDependenciesMeta:
+      arc-templates:
+        optional: true
+      atpl:
+        optional: true
+      babel-core:
+        optional: true
+      bracket-template:
+        optional: true
+      coffee-script:
+        optional: true
+      dot:
+        optional: true
+      dust:
+        optional: true
+      dustjs-helpers:
+        optional: true
+      dustjs-linkedin:
+        optional: true
+      eco:
+        optional: true
+      ect:
+        optional: true
+      ejs:
+        optional: true
+      haml-coffee:
+        optional: true
+      hamlet:
+        optional: true
+      hamljs:
+        optional: true
+      handlebars:
+        optional: true
+      hogan.js:
+        optional: true
+      htmling:
+        optional: true
+      jade:
+        optional: true
+      jazz:
+        optional: true
+      jqtpl:
+        optional: true
+      just:
+        optional: true
+      liquid-node:
+        optional: true
+      liquor:
+        optional: true
+      lodash:
+        optional: true
+      marko:
+        optional: true
+      mote:
+        optional: true
+      mustache:
+        optional: true
+      nunjucks:
+        optional: true
+      plates:
+        optional: true
+      pug:
+        optional: true
+      qejs:
+        optional: true
+      ractive:
+        optional: true
+      razor-tmpl:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      slm:
+        optional: true
+      squirrelly:
+        optional: true
+      swig:
+        optional: true
+      swig-templates:
+        optional: true
+      teacup:
+        optional: true
+      templayed:
+        optional: true
+      then-jade:
+        optional: true
+      then-pug:
+        optional: true
+      tinyliquid:
+        optional: true
+      toffee:
+        optional: true
+      twig:
+        optional: true
+      twing:
+        optional: true
+      underscore:
+        optional: true
+      vash:
+        optional: true
+      velocityjs:
+        optional: true
+      walrus:
+        optional: true
+      whiskers:
+        optional: true
     dependencies:
       bluebird: 3.7.2
     dev: true
@@ -2471,7 +2717,7 @@ packages:
     hasBin: true
     dependencies:
       graceful-fs: 4.2.8
-      minimist: 1.2.5
+      minimist: 1.2.6
       mkdirp: 0.5.6
       rimraf: 2.7.1
     dev: true
@@ -2546,12 +2792,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -2742,7 +2998,7 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-config-standard-with-typescript/21.0.1_7011e4c6b6506c7ee39552f76c4c1b28:
+  /eslint-config-standard-with-typescript/21.0.1_oai6jrvwkbwh5y4vkl3wyta3fa:
     resolution: {integrity: sha512-FeiMHljEJ346Y0I/HpAymNKdrgKEpHpcg/D93FvPHWfCzbT4QyUJba/0FwntZeGLXfUiWDSeKmdJD597d9wwiw==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^4.0.1
@@ -2752,11 +3008,11 @@ packages:
       eslint-plugin-promise: ^4.2.1 || ^5.0.0
       typescript: ^3.9 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0_4c993576e6b922da56fd69e292b3693f
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
+      '@typescript-eslint/eslint-plugin': 4.33.0_jsmtk5xgxernuvx5nhrjfm3jh4
+      '@typescript-eslint/parser': 4.33.0_wnilx7boviscikmvsfkd6ljepe
       eslint: 7.32.0
-      eslint-config-standard: 16.0.3_c064783008e6437da98d184fd45815b6
-      eslint-plugin-import: 2.25.3_eslint@7.32.0
+      eslint-config-standard: 16.0.3_ybshqmai4zbx3kmndbh5iwavwy
+      eslint-plugin-import: 2.25.3_cxmo2kyoere6f7tblsdv7itcme
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-promise: 5.1.1_eslint@7.32.0
       typescript: 4.4.4
@@ -2764,7 +3020,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-standard/16.0.3_c064783008e6437da98d184fd45815b6:
+  /eslint-config-standard/16.0.3_ybshqmai4zbx3kmndbh5iwavwy:
     resolution: {integrity: sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==}
     peerDependencies:
       eslint: ^7.12.1
@@ -2773,7 +3029,7 @@ packages:
       eslint-plugin-promise: ^4.2.1 || ^5.0.0
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-import: 2.25.3_eslint@7.32.0
+      eslint-plugin-import: 2.25.3_cxmo2kyoere6f7tblsdv7itcme
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-promise: 5.1.1_eslint@7.32.0
     dev: true
@@ -2783,15 +3039,35 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.20.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.1:
+  /eslint-module-utils/2.7.1_hwco3v65td3xge2elnr7q3lsmm:
     resolution: {integrity: sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 4.0.0_wnilx7boviscikmvsfkd6ljepe
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
       pkg-dir: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
@@ -2805,19 +3081,24 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import/2.25.3_eslint@7.32.0:
+  /eslint-plugin-import/2.25.3_cxmo2kyoere6f7tblsdv7itcme:
     resolution: {integrity: sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 4.0.0_wnilx7boviscikmvsfkd6ljepe
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.1
+      eslint-module-utils: 2.7.1_hwco3v65td3xge2elnr7q3lsmm
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
@@ -2825,6 +3106,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.20.0
       tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-node/11.1.0_eslint@7.32.0:
@@ -3651,7 +3936,7 @@ packages:
     resolution: {integrity: sha512-kfZYSmleFqvoue4AkP0WSNt1rWXNCWhcD/iUGxLzEC0ENVypoAFRsn7i8ekC3pdd+LrzIKoYCezqju8yjIM8Wg==}
     hasBin: true
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.17.9
       babel-template: 6.26.0
       cpr: 3.0.1
       cross-spawn: 7.0.3
@@ -3681,6 +3966,8 @@ packages:
       read-json-sync: 2.0.1
       resolve: 1.20.0
       semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /liferay-npm-bundler-plugin-exclude-imports/2.28.3:
@@ -3736,6 +4023,8 @@ packages:
       liferay-npm-bundler-plugin-namespace-packages: 2.28.3
       liferay-npm-bundler-plugin-replace-browser-modules: 2.28.3
       liferay-npm-bundler-plugin-resolve-linked-dependencies: 2.28.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /liferay-npm-bundler/2.28.3:
@@ -3759,6 +4048,8 @@ packages:
       semver: 6.3.0
       xml-js: 1.6.11
       yargs: 14.2.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /loader-utils/0.2.17:
@@ -4172,7 +4463,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-organize-imports/2.3.4_prettier@2.5.0+typescript@4.4.4:
+  /prettier-plugin-organize-imports/2.3.4_5j2uxzfklibigmd5tyodhypk6e:
     resolution: {integrity: sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==}
     peerDependencies:
       prettier: '>=2.0'
@@ -4447,7 +4738,7 @@ packages:
       is-plain-object: 3.0.1
     dev: true
 
-  /rollup-plugin-esbuild/4.7.2_esbuild@0.12.29+rollup@2.60.2:
+  /rollup-plugin-esbuild/4.7.2_6o6s27zuiu65oylrocermxngny:
     resolution: {integrity: sha512-rBS2hTedtG+wL/yyIWQ84zju5rtfF15gkaCLN0vsWGmBdRd0UPm52meAwkmrsPQf3mB/H2o+k9Q8Ce8A66SE5A==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -4470,12 +4761,12 @@ packages:
       rollup: 2.60.2
     dev: true
 
-  /rollup-plugin-vue/4.7.2_84f1ab3facf9297d480226d5fd2946c7:
+  /rollup-plugin-vue/4.7.2_qty2wp5m7eux2sace3k72kkgy4:
     resolution: {integrity: sha512-RuAK+YTL81/iccOWoadqQz2TXqOogivjbvtCuU6EfVP9/E5XIjuMNVsVWHkSelZQblI1z2b5tshWL7XoiOfABQ==}
     peerDependencies:
       vue-template-compiler: '*'
     dependencies:
-      '@vue/component-compiler': 3.6.0_84f1ab3facf9297d480226d5fd2946c7
+      '@vue/component-compiler': 3.6.0_qty2wp5m7eux2sace3k72kkgy4
       '@vue/component-compiler-utils': 2.6.0
       debug: 4.3.3
       hash-sum: 1.0.2
@@ -4486,8 +4777,61 @@ packages:
       vue-runtime-helpers: 1.0.0
       vue-template-compiler: 2.6.14
     transitivePeerDependencies:
+      - arc-templates
+      - atpl
+      - babel-core
+      - bracket-template
+      - coffee-script
+      - dot
+      - dust
+      - dustjs-helpers
+      - dustjs-linkedin
+      - eco
+      - ect
+      - ejs
+      - haml-coffee
+      - hamlet
+      - hamljs
+      - handlebars
+      - hogan.js
+      - htmling
+      - jade
+      - jazz
+      - jqtpl
+      - just
+      - liquid-node
+      - liquor
+      - lodash
+      - marko
+      - mote
+      - mustache
+      - nunjucks
+      - plates
       - postcss
+      - pug
+      - qejs
+      - ractive
+      - razor-tmpl
+      - react
+      - react-dom
+      - slm
+      - squirrelly
       - supports-color
+      - swig
+      - swig-templates
+      - teacup
+      - templayed
+      - then-jade
+      - then-pug
+      - tinyliquid
+      - toffee
+      - twig
+      - twing
+      - underscore
+      - vash
+      - velocityjs
+      - walrus
+      - whiskers
     dev: true
 
   /rollup-pluginutils/2.8.2:


### PR DESCRIPTION
This implements the possibility to copy assets, copy sources and only create the transpiled js file in the build instead of a jar file.